### PR TITLE
Test: Verify Scalpel trim mode (box only)

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -808,8 +808,8 @@ jobs:
                 echo "Analyzing dependencies for example: $MODULE"
                 cd ${MODULE}
 
-                # Use root pom.xml approach to list dependencies
-                ./mvnw ${CQ_MAVEN_ARGS} dependency:list -DoutputFile=target/deps.txt -DincludeGroupIds=org.apache.camel.quarkus -q 2>/dev/null || true
+                # Use quarkus:dependency-list which works per-module (root pom.xml is just an aggregator)
+                ../mvnw ${CQ_MAVEN_ARGS} quarkus:dependency-list -DoutputFile=target/deps.txt -q 2>/dev/null || true
 
                 if [ -f target/deps.txt ]; then
                   # Check if any affected extension appears in dependencies

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -533,9 +533,7 @@ jobs:
     env:
       MAVEN_OPTS: -Xmx3000m
       SCALPEL_ENABLED: "-Dscalpel.enabled=true"
-      # TEMPORARY: Removed tooling/maven-plugin/** to allow testing plugin changes without full builds
-      SCALPEL_FULL_BUILD_TRIGGERS: "-Dscalpel.fullBuildTriggers=poms/**,extensions-core/core/**,.mvn/**,pom.xml"
-      SCALPEL_EXCLUDE_PATHS: "-Dscalpel.excludePaths=docs/**,.github/workflows/ci-build.yaml,tooling/maven-plugin/**"
+      SCALPEL_FULL_BUILD_TRIGGERS: "-Dscalpel.fullBuildTriggers=poms/**,extensions-core/core/**,tooling/maven-plugin/**,.mvn/**,pom.xml"
       SCALPEL_ALSO_MAKE: "-Dscalpel.alsoMake=true"
       SCALPEL_ALSO_MAKE_DEPENDENTS: "-Dscalpel.alsoMakeDependents=false"
     steps:
@@ -564,7 +562,6 @@ jobs:
             ${SCALPEL_ALSO_MAKE} \
             ${SCALPEL_ALSO_MAKE_DEPENDENTS} \
             ${SCALPEL_FULL_BUILD_TRIGGERS} \
-            ${SCALPEL_EXCLUDE_PATHS} \
             --fail-at-end \
             test
       - name: Report test failures

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -802,6 +802,7 @@ jobs:
               echo "Core extension affected - building all examples"
             else
               # Filter examples based on dependency analysis
+              echo "Affected modules for filtering: $AFFECTED_MODULES"
               FILTERED_MODULES=()
 
               for MODULE in ${EXAMPLE_MODULES//,/ }; do
@@ -809,9 +810,11 @@ jobs:
                 cd ${MODULE}
 
                 # Use quarkus:dependency-list which works per-module (root pom.xml is just an aggregator)
-                ../mvnw ${CQ_MAVEN_ARGS} quarkus:dependency-list -DoutputFile=target/deps.txt -q 2>/dev/null || true
+                echo "  Running: ../mvnw quarkus:dependency-list -DoutputFile=target/deps.txt -q"
+                ../mvnw ${CQ_MAVEN_ARGS} quarkus:dependency-list -DoutputFile=target/deps.txt -q 2>&1 || true
 
                 if [ -f target/deps.txt ]; then
+                  echo "  ✓ deps.txt created ($(wc -l < target/deps.txt) lines)"
                   # Check if any affected extension appears in dependencies
                   SHOULD_BUILD=false
                   for AFFECTED in $AFFECTED_MODULES; do

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -752,6 +752,7 @@ jobs:
     if: |
       (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'JVM'))
       && needs.initial-mvn-install.outputs.run-examples == 'true'
+      && needs.initial-mvn-install.outputs.run-examples == 'true'
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.initial-mvn-install.outputs.examples-matrix) }}

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -752,7 +752,6 @@ jobs:
     if: |
       (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'JVM'))
       && needs.initial-mvn-install.outputs.run-examples == 'true'
-      && needs.initial-mvn-install.outputs.run-examples == 'true'
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.initial-mvn-install.outputs.examples-matrix) }}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension</artifactId>
+        <version>0.3.3</version>
+    </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,5 @@
 -Daether.remoteRepositoryFilter.groupId=true
 -Daether.remoteRepositoryFilter.groupId.basedir=${session.rootDirectory}/.mvn/rrf/
+
+# Scalpel is disabled by default, only enabled in specific CI steps
+-Dscalpel.enabled=false

--- a/extensions/box/deployment/src/main/java/org/apache/camel/quarkus/component/box/deployment/BoxProcessor.java
+++ b/extensions/box/deployment/src/main/java/org/apache/camel/quarkus/component/box/deployment/BoxProcessor.java
@@ -51,3 +51,4 @@ class BoxProcessor {
         runtimeClasses.produce(new RuntimeInitializedClassBuildItem(BoxAPIRequest.class.getCanonicalName()));
     }
 }
+// Test: verify Scalpel trim mode behavior in functional tests


### PR DESCRIPTION
## Purpose
Test whether Scalpel trim mode correctly filters functional extension tests.

## Test Setup
- **Base**: test-incremental-rebased (has all incremental build logic)
- **Change**: Single line added to BoxProcessor.java
- **Diff**: Only 1 file changed, incremental build should be active

## Expected Behavior
Scalpel should detect only box extension as affected.

## What to Check

**Scalpel Analysis step:**
Should show only box in affected modules.

**Functional Extension Tests - `cd extensions && mvn test` step:**

**If trim mode works:**
- Reactor shows only Box modules
- Fast (~1-2 min)

**If trim mode fails:**
- Reactor shows ALL extensions (100+)  
- Slow (~20+ min)

## Hypothesis
Scalpel trim mode fails silently when run from subdirectories.