### PR TITLE
Test Scenario 3: JVM-only extension (ehcache)

### DIFF
--- a/extensions-jvm/ehcache/deployment/src/main/java/org/apache/camel/quarkus/component/ehcache/deployment/EhcacheProcessor.java
+++ b/extensions-jvm/ehcache/deployment/src/main/java/org/apache/camel/quarkus/component/ehcache/deployment/EhcacheProcessor.java
@@ -25,6 +25,7 @@ import org.apache.camel.quarkus.core.JvmOnlyRecorder;
 import org.jboss.logging.Logger;
 
 class EhcacheProcessor {
+    // Test change: verify JVM-only extension triggers JVM tests only
 
     private static final Logger LOG = Logger.getLogger(EhcacheProcessor.class);
     private static final String FEATURE = "camel-ehcache";


### PR DESCRIPTION
Test incremental build with JVM-only extension change.

**Expected:**
- ✅ Only ehcache JVM tests run
- ✅ Native tests skipped
- ✅ Examples skipped
- ✅ Full build NOT triggered