### PR TITLE
Test: CSV extension dependency change for incremental build

### DIFF
--- a/extensions/csv/deployment/pom.xml
+++ b/extensions/csv/deployment/pom.xml
@@ -38,6 +38,10 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-csv</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-netty-deployment</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/csv/runtime/pom.xml
+++ b/extensions/csv/runtime/pom.xml
@@ -43,6 +43,10 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-csv</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-netty</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Testing that adding a dependency to an extension module (csv) triggers incremental build.

**Changes:**
- Added quarkus-netty dependency to csv/runtime
- Added quarkus-netty-deployment dependency to csv/deployment

**Expected behavior:**
- Scalpel detects changes to extensions/csv/runtime and extensions/csv/deployment
- Only csv extension and integration-tests/csv affected
- Native test matrix: 1 group with csv only
- Functional tests: Only extensions/ tests should run