### PR TITLE
Test: MongoDB container version bump (support module detection)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
         <mariadb.container.image>mirror.gcr.io/mariadb:12.2-ubi</mariadb.container.image>
         <milvus.container.image>mirror.gcr.io/milvusdb/milvus:v2.3.9</milvus.container.image>
         <minio.container.image>mirror.gcr.io/minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1</minio.container.image>
-        <mongodb.container.image>mirror.gcr.io/mongo:7.0</mongodb.container.image>
+        <mongodb.container.image>mirror.gcr.io/mongo:8.0</mongodb.container.image>
         <mysql.container.image>mirror.gcr.io/mysql:9.5</mysql.container.image>
         <nats.container.image>mirror.gcr.io/nats:2.11.6</nats.container.image>
         <opensearch.container.image>mirror.gcr.io/opensearchproject/opensearch:3.1.0</opensearch.container.image>


### PR DESCRIPTION
## Summary
- Bumps `mongodb.container.image` from 7.0 to 8.0 to test support module dependency resolution
- The property is referenced in `integration-tests-support/mongodb`, not directly in test modules
- Expected affected modules: `mongodb-grouped`, `debezium-grouped` (from integration-tests) and `mongodb-grouped`, `debezium-grouped` (from integration-test-groups)

## Test plan
- [ ] Verify `Detect Changed Container Properties` step outputs `mongodb.container.image`
- [ ] Verify Mojo resolves `integration-tests-support/mongodb` dependents
- [ ] Verify native test matrix contains only mongodb and debezium groups