### PR TITLE
Test: Direct integration test change (sql)

### DIFF
--- a/integration-tests/sql/src/test/java/org/apache/camel/quarkus/component/sql/it/SqlTest.java
+++ b/integration-tests/sql/src/test/java/org/apache/camel/quarkus/component/sql/it/SqlTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.quarkus.component.sql.it;
 
+// Test change for incremental build verification
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
## Summary
- Adds a comment to `SqlTest.java` in `integration-tests/sql/`
- Expected: incremental build detects only `sql` as affected, native matrix has one group

## Test plan
- [ ] Verify Scalpel reports `integration-tests/sql` as the only affected module
- [ ] Verify native test matrix contains a single group with `sql`
- [ ] Verify no functional extension tests or JVM tests run