### PR TITLE
Test: Doc-only change (should skip all tests)

### DIFF
--- a/docs/modules/ROOT/pages/user-guide/cdi.adoc
+++ b/docs/modules/ROOT/pages/user-guide/cdi.adoc
@@ -1,7 +1,7 @@
 = Contexts and Dependency Injection (CDI) in Camel Quarkus
 :page-aliases: cdi.adoc
 
-CDI plays a central role in Quarkus and Camel Quarkus offers a first class support for it too.
+CDI plays a central role in Quarkus and Camel Quarkus offers first class support for it too.
 
 You may use `@Inject`, `@ConfigProperty` and similar annotations e.g. to inject beans and configuration values to
 your Camel `RouteBuilder`. Here is the `RouteBuilder` from our `timer-log-cdi` xref:user-guide/examples.adoc[example]:


### PR DESCRIPTION
## Summary
- Minor wording fix in `cdi.adoc`
- `.adoc` files are in `SCALPEL_EXCLUDE_PATHS`, so Scalpel should report no affected modules

## Test plan
- [ ] Verify Scalpel reports 0 affected modules, no full build triggered
- [ ] Verify native test matrix is empty (no native test groups run)
- [ ] Verify functional-extension-tests, integration-tests-jvm are skipped