### PR TITLE
Test: Core change (should trigger full build)

### DIFF
--- a/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelConfig.java
+++ b/extensions-core/core/runtime/src/main/java/org/apache/camel/quarkus/core/CamelConfig.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.quarkus.core;
 
+// Test change for full build trigger verification
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;


### PR DESCRIPTION
## Summary
- Adds a comment to `CamelConfig.java` in `extensions-core/core/`
- `extensions-core/core/**` is in `SCALPEL_FULL_BUILD_TRIGGERS` for initial-mvn-install
- Expected: full build triggered, all native test groups run

## Test plan
- [ ] Verify Scalpel reports `fullBuildTriggered: true`
- [ ] Verify all 13 native test groups run
- [ ] Verify all functional-extension-tests run