### PR TITLE
Test: JVM-only test change (barcode)

### DIFF
--- a/integration-tests-jvm/barcode/src/test/java/org/apache/camel/quarkus/component/barcode/it/BarcodeTest.java
+++ b/integration-tests-jvm/barcode/src/test/java/org/apache/camel/quarkus/component/barcode/it/BarcodeTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.quarkus.component.barcode.it;
 
+// Test change for JVM test detection verification
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Summary
- Adds a comment to `BarcodeTest.java` in `integration-tests-jvm/barcode/`
- Expected: incremental build detects `barcode` as a JVM-only test module
- No native tests should run

## Test plan
- [ ] Verify Mojo reports `barcode` in JVM test modules
- [ ] Verify no native test groups run (empty matrix)
- [ ] Verify integration-tests-jvm job runs with only `barcode`